### PR TITLE
delete時に投稿者をバックエンド側で処理するように修正

### DIFF
--- a/backend/app/application/comment_app_test.go
+++ b/backend/app/application/comment_app_test.go
@@ -20,10 +20,12 @@ func TestCommentApp_GetAllByThreadKey(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
+	userRepository := mock_repository.NewMockUserRepository(mockCtrl)
 	threadRepository := mock_repository.NewMockThreadRepository(mockCtrl)
 	commentRepository := mock_repository.NewMockCommentRepository(mockCtrl)
 
 	type mockField struct {
+		userRepository    *mock_repository.MockUserRepository
 		threadRepository  *mock_repository.MockThreadRepository
 		commentRepository *mock_repository.MockCommentRepository
 	}
@@ -33,7 +35,7 @@ func TestCommentApp_GetAllByThreadKey(t *testing.T) {
 		commentRepository: commentRepository,
 	}
 
-	commentApplication := application.NewCommentApplication(threadRepository, commentRepository)
+	commentApplication := application.NewCommentApplication(userRepository, threadRepository, commentRepository)
 
 	//
 	// execute
@@ -91,10 +93,12 @@ func TestCommentApp_CreateComment(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
+	userRepository := mock_repository.NewMockUserRepository(mockCtrl)
 	threadRepository := mock_repository.NewMockThreadRepository(mockCtrl)
 	commentRepository := mock_repository.NewMockCommentRepository(mockCtrl)
 
 	type mockField struct {
+		userRepository    *mock_repository.MockUserRepository
 		threadRepository  *mock_repository.MockThreadRepository
 		commentRepository *mock_repository.MockCommentRepository
 	}
@@ -104,7 +108,7 @@ func TestCommentApp_CreateComment(t *testing.T) {
 		commentRepository: commentRepository,
 	}
 
-	commentApplication := application.NewCommentApplication(threadRepository, commentRepository)
+	commentApplication := application.NewCommentApplication(userRepository, threadRepository, commentRepository)
 
 	//
 	// execute
@@ -177,10 +181,12 @@ func TestCommentApp_EditComment(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
+	userRepository := mock_repository.NewMockUserRepository(mockCtrl)
 	threadRepository := mock_repository.NewMockThreadRepository(mockCtrl)
 	commentRepository := mock_repository.NewMockCommentRepository(mockCtrl)
 
 	type mockField struct {
+		userRepository    *mock_repository.MockUserRepository
 		threadRepository  *mock_repository.MockThreadRepository
 		commentRepository *mock_repository.MockCommentRepository
 	}
@@ -190,7 +196,7 @@ func TestCommentApp_EditComment(t *testing.T) {
 		commentRepository: commentRepository,
 	}
 
-	commentApplication := application.NewCommentApplication(threadRepository, commentRepository)
+	commentApplication := application.NewCommentApplication(userRepository, threadRepository, commentRepository)
 
 	//
 	// exucute
@@ -290,20 +296,23 @@ func TestCommentApp_DeleteComment(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
+	userRepository := mock_repository.NewMockUserRepository(mockCtrl)
 	threadRepository := mock_repository.NewMockThreadRepository(mockCtrl)
 	commentRepository := mock_repository.NewMockCommentRepository(mockCtrl)
 
 	type mockField struct {
+		userRepository    *mock_repository.MockUserRepository
 		threadRepository  *mock_repository.MockThreadRepository
 		commentRepository *mock_repository.MockCommentRepository
 	}
 
 	field := mockField{
+		userRepository: userRepository,
 		threadRepository:  threadRepository,
 		commentRepository: commentRepository,
 	}
 
-	commentApplication := application.NewCommentApplication(threadRepository, commentRepository)
+	commentApplication := application.NewCommentApplication(userRepository, threadRepository, commentRepository)
 
 	//
 	// exucute
@@ -312,13 +321,16 @@ func TestCommentApp_DeleteComment(t *testing.T) {
 		correctThreadKey   = "correct-thread-key"
 		correctCommentKey  = "correct-comment-key"
 		correctContributor = "correct-contributor"
+		correctUserID      = "correct-userID"
 		wrongThreadKey     = "wrong-thread-key"
 		wrongCommentKey    = "wrong-comment-key"
 		wrongContributor   = "wrong-contributor"
+		wrongUserID        = "wrong-userID"
 		initialCommentSum  = 100
 		thread             = domain.Thread{Key: correctThreadKey, CommentSum: &initialCommentSum}
 		comment            = domain.Comment{Key: correctCommentKey, ThreadKey: correctThreadKey, Contributor: correctContributor}
-		comments           = []domain.Comment{}
+		correctUser        = domain.User{Username: correctContributor}
+		wrongUser          = domain.User{Username: wrongContributor}
 	)
 	cases := []struct {
 		testCase         string
@@ -333,7 +345,6 @@ func TestCommentApp_DeleteComment(t *testing.T) {
 			prepare: func(mf *mockField) {
 				mf.threadRepository.EXPECT().GetByKey(wrongThreadKey).Return(nil, appError.ErrNotFound)
 			},
-			expectedComments: nil,
 			expectedError:    appError.ErrNotFound,
 		},
 		{
@@ -343,30 +354,28 @@ func TestCommentApp_DeleteComment(t *testing.T) {
 				mf.threadRepository.EXPECT().GetByKey(correctThreadKey).Return(&thread, nil)
 				mf.commentRepository.EXPECT().GetByKey(wrongCommentKey).Return(nil, appError.ErrNotFound)
 			},
-			expectedComments: nil,
 			expectedError:    appError.ErrNotFound,
 		},
 		{
 			testCase: "違うユーザーは削除できない",
-			input:    params.DeleteCommentAppLayerParam{ThreadKey: correctThreadKey, CommentKey: correctCommentKey, Contributor: wrongContributor},
+			input:    params.DeleteCommentAppLayerParam{ThreadKey: correctThreadKey, CommentKey: correctCommentKey, UserID: wrongUserID},
 			prepare: func(mf *mockField) {
 				mf.threadRepository.EXPECT().GetByKey(correctThreadKey).Return(&thread, nil)
 				mf.commentRepository.EXPECT().GetByKey(correctCommentKey).Return(&comment, nil)
+				mf.userRepository.EXPECT().GetByID(wrongUserID).Return(&wrongUser, nil)
 			},
-			expectedComments: nil,
 			expectedError:    &appError.BadRequest{},
 		},
 		{
-			testCase: "正常なパラメータであれば成功する",
-			input:    params.DeleteCommentAppLayerParam{ThreadKey: correctThreadKey, CommentKey: correctCommentKey, Contributor: correctContributor},
+			testCase: "コメントの削除が完了すれば成功する",
+			input:    params.DeleteCommentAppLayerParam{ThreadKey: correctThreadKey, CommentKey: correctCommentKey, UserID: correctUserID},
 			prepare: func(mf *mockField) {
 				mf.threadRepository.EXPECT().GetByKey(correctThreadKey).Return(&thread, nil)
 				mf.commentRepository.EXPECT().GetByKey(correctCommentKey).Return(&comment, nil)
+				mf.userRepository.EXPECT().GetByID(correctUserID).Return(&correctUser, nil)
 				mf.commentRepository.EXPECT().Delete(gomock.Any()).Return(nil)
 				mf.threadRepository.EXPECT().Update(gomock.Any()).Return(nil, nil)
-				mf.commentRepository.EXPECT().GetAllByKey(correctThreadKey).Return(&comments, nil)
 			},
-			expectedComments: &comments,
 			expectedError:    nil,
 		},
 	}
@@ -374,11 +383,8 @@ func TestCommentApp_DeleteComment(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.testCase, func(t *testing.T) {
 			c.prepare(&field)
-			comments, err := commentApplication.DeleteComment(&c.input)
+			err := commentApplication.DeleteComment(&c.input)
 
-			if comments != c.expectedComments {
-				t.Errorf("different comments.\nwant: %v\ngot: %v", c.expectedComments, comments)
-			}
 			if !isSameError(err, c.expectedError) {
 				t.Errorf("different error.\nwant: %s\ngot: %s", c.expectedError, err)
 			}

--- a/backend/app/application/params/comment.go
+++ b/backend/app/application/params/comment.go
@@ -14,7 +14,7 @@ type EditCommentAppLayerParam struct {
 }
 
 type DeleteCommentAppLayerParam struct {
-	ThreadKey   string
-	CommentKey  string
-	Contributor string
+	ThreadKey  string
+	CommentKey string
+	UserID     string
 }

--- a/backend/app/application/params/thread.go
+++ b/backend/app/application/params/thread.go
@@ -12,6 +12,6 @@ type EditThreadAppLayerParam struct {
 }
 
 type DeleteThreadAppLayerParam struct {
-	ThreadKey   string
-	Contributor string
+	ThreadKey string
+	UserID    string
 }

--- a/backend/app/interfaces/request/comment.go
+++ b/backend/app/interfaces/request/comment.go
@@ -9,7 +9,3 @@ type RequestCommentEdit struct {
 	Comment     string `json:"comment" binding:"required"`
 	Contributor string `json:"contributor" binding:"required"`
 }
-
-type RequestCommentDelete struct {
-	Contributor string `json:"contributor" binding:"required"`
-}

--- a/backend/app/interfaces/request/thread.go
+++ b/backend/app/interfaces/request/thread.go
@@ -9,7 +9,3 @@ type RequestThreadEdit struct {
 	Title       string `json:"title" binding:"required"`
 	Contributor string `json:"contributor" binding:"required"`
 }
-
-type RequestThreadDelete struct {
-	Contributor string `json:"contributor" binding:"required"`
-}

--- a/backend/app/interfaces/thread_handler.go
+++ b/backend/app/interfaces/thread_handler.go
@@ -181,8 +181,7 @@ func (t *ThreadHandler) edit(c *gin.Context) {
 // @Accept json
 // @Produce json
 // @Param threadKey path string true "スレッドキー"
-// @Param body body request.RequestThreadDelete true "スレッド削除情報"
-// @Success 200
+// @Success 204
 // @Failure 400
 // @Failure 401
 // @Failure 404
@@ -191,17 +190,11 @@ func (t *ThreadHandler) edit(c *gin.Context) {
 // Thread godoc
 func (t *ThreadHandler) delete(c *gin.Context) {
 	threadKey := c.Param("threadKey")
-
-	var req request.RequestThreadDelete
-	if err := c.ShouldBindJSON(&req); err != nil {
-		logger.Error("thread delete, requesting json bind error", "error", err, "binded_request", req)
-		handleError(c, err)
-		return
-	}
+	user, _ := t.sessionManager.Get(c)
 
 	param := params.DeleteThreadAppLayerParam{
-		ThreadKey:   threadKey,
-		Contributor: req.Contributor,
+		ThreadKey: threadKey,
+		UserID:    user.UserID,
 	}
 
 	if err := t.threadApplication.DeleteThread(&param); err != nil {

--- a/backend/app/mock/application/comment_app.go
+++ b/backend/app/mock/application/comment_app.go
@@ -51,12 +51,11 @@ func (mr *MockCommentApplicationMockRecorder) CreateComment(param interface{}) *
 }
 
 // DeleteComment mocks base method.
-func (m *MockCommentApplication) DeleteComment(param *params.DeleteCommentAppLayerParam) (*[]domain.Comment, error) {
+func (m *MockCommentApplication) DeleteComment(param *params.DeleteCommentAppLayerParam) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteComment", param)
-	ret0, _ := ret[0].(*[]domain.Comment)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // DeleteComment indicates an expected call of DeleteComment.

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -208,19 +208,10 @@ const docTemplate = `{
                         "name": "threadKey",
                         "in": "path",
                         "required": true
-                    },
-                    {
-                        "description": "スレッド削除情報",
-                        "name": "body",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/request.RequestThreadDelete"
-                        }
                     }
                 ],
                 "responses": {
-                    "200": {
+                    "204": {
                         "description": ""
                     },
                     "400": {
@@ -418,23 +409,11 @@ const docTemplate = `{
                         "name": "commentKey",
                         "in": "path",
                         "required": true
-                    },
-                    {
-                        "description": "コメント削除情報",
-                        "name": "body",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/request.RequestCommentDelete"
-                        }
                     }
                 ],
                 "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/response.ResponseThreadAndComments"
-                        }
+                    "204": {
+                        "description": ""
                     },
                     "400": {
                         "description": ""
@@ -740,17 +719,6 @@ const docTemplate = `{
                 }
             }
         },
-        "request.RequestCommentDelete": {
-            "type": "object",
-            "required": [
-                "contributor"
-            ],
-            "properties": {
-                "contributor": {
-                    "type": "string"
-                }
-            }
-        },
         "request.RequestCommentEdit": {
             "type": "object",
             "required": [
@@ -807,17 +775,6 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "title": {
-                    "type": "string"
-                }
-            }
-        },
-        "request.RequestThreadDelete": {
-            "type": "object",
-            "required": [
-                "contributor"
-            ],
-            "properties": {
-                "contributor": {
                     "type": "string"
                 }
             }

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -201,19 +201,10 @@
                         "name": "threadKey",
                         "in": "path",
                         "required": true
-                    },
-                    {
-                        "description": "スレッド削除情報",
-                        "name": "body",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/request.RequestThreadDelete"
-                        }
                     }
                 ],
                 "responses": {
-                    "200": {
+                    "204": {
                         "description": ""
                     },
                     "400": {
@@ -411,23 +402,11 @@
                         "name": "commentKey",
                         "in": "path",
                         "required": true
-                    },
-                    {
-                        "description": "コメント削除情報",
-                        "name": "body",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/request.RequestCommentDelete"
-                        }
                     }
                 ],
                 "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/response.ResponseThreadAndComments"
-                        }
+                    "204": {
+                        "description": ""
                     },
                     "400": {
                         "description": ""
@@ -733,17 +712,6 @@
                 }
             }
         },
-        "request.RequestCommentDelete": {
-            "type": "object",
-            "required": [
-                "contributor"
-            ],
-            "properties": {
-                "contributor": {
-                    "type": "string"
-                }
-            }
-        },
         "request.RequestCommentEdit": {
             "type": "object",
             "required": [
@@ -800,17 +768,6 @@
                     "type": "string"
                 },
                 "title": {
-                    "type": "string"
-                }
-            }
-        },
-        "request.RequestThreadDelete": {
-            "type": "object",
-            "required": [
-                "contributor"
-            ],
-            "properties": {
-                "contributor": {
                     "type": "string"
                 }
             }

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -17,13 +17,6 @@ definitions:
     - comment
     - contributor
     type: object
-  request.RequestCommentDelete:
-    properties:
-      contributor:
-        type: string
-    required:
-    - contributor
-    type: object
   request.RequestCommentEdit:
     properties:
       comment:
@@ -63,13 +56,6 @@ definitions:
     required:
     - contributor
     - title
-    type: object
-  request.RequestThreadDelete:
-    properties:
-      contributor:
-        type: string
-    required:
-    - contributor
     type: object
   request.RequestThreadEdit:
     properties:
@@ -206,16 +192,10 @@ paths:
         name: threadKey
         required: true
         type: string
-      - description: スレッド削除情報
-        in: body
-        name: body
-        required: true
-        schema:
-          $ref: '#/definitions/request.RequestThreadDelete'
       produces:
       - application/json
       responses:
-        "200":
+        "204":
           description: ""
         "400":
           description: ""
@@ -369,19 +349,11 @@ paths:
         name: commentKey
         required: true
         type: string
-      - description: コメント削除情報
-        in: body
-        name: body
-        required: true
-        schema:
-          $ref: '#/definitions/request.RequestCommentDelete'
       produces:
       - application/json
       responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/response.ResponseThreadAndComments'
+        "204":
+          description: ""
         "400":
           description: ""
         "401":

--- a/backend/main.go
+++ b/backend/main.go
@@ -95,8 +95,8 @@ func main() {
 	// application
 	userApp := application.NewUserApplication(userDB)
 	visitApp := application.NewVisitorApplication(visitorDB)
-	threadApp := application.NewThreadApplication(threadDB, commentDB)
-	commentApp := application.NewCommentApplication(threadDB, commentDB)
+	threadApp := application.NewThreadApplication(userDB, threadDB, commentDB)
+	commentApp := application.NewCommentApplication(userDB, threadDB, commentDB)
 
 	// handler
 	userHandler := interfaces.NewUserHandler(session, userApp)


### PR DESCRIPTION
Fixes #60

- delete時にフロントから投稿者情報を送信していましたが、それをバックエンドのセッション処理に組み込むことで、フロントで送らなくてもいいようにしました
- それに伴い、テストの修正も行っています