### PR TITLE
コメントAPIのPOST/PUTでリターンされるデータの修正

### DIFF
--- a/backend/app/interfaces/comment_handler.go
+++ b/backend/app/interfaces/comment_handler.go
@@ -89,7 +89,7 @@ func (co *CommentHandler) getAll(c *gin.Context) {
 // @Produce json
 // @Param threadKey path string true "スレッドキー"
 // @Param body body request.RequestCommentCreate true "コメント作成情報"
-// @Success 200 {object} response.ResponseThreadAndComments
+// @Success 200 {object} response.ResponseComment
 // @Failure 400
 // @Failure 401
 // @Failure 404
@@ -112,23 +112,13 @@ func (co *CommentHandler) create(c *gin.Context) {
 		Contributor: req.Contributor,
 	}
 
-	comments, err := co.commentApplication.CreateComment(&param)
+	comment, err := co.commentApplication.CreateComment(&param)
 	if err != nil {
 		handleError(c, err)
 		return
 	}
 
-	thread, err := co.threadApplication.GetByThreadKey(threadKey)
-	if err != nil {
-		handleError(c, err)
-		return
-	}
-
-	var res response.ResponseThreadAndComments
-	res.Thread = response.NewResponseThread(thread)
-	for _, comment := range *comments {
-		res.Comments = append(res.Comments, response.NewResponseComment(&comment))
-	}
+	res := response.NewResponseComment(comment)
 
 	c.JSON(http.StatusOK, res)
 }
@@ -142,7 +132,7 @@ func (co *CommentHandler) create(c *gin.Context) {
 // @Param threadKey path string true "スレッドキー"
 // @Param commentKey path string true "コメントキー"
 // @Param body body request.RequestCommentEdit true "コメント編集情報"
-// @Success 200 {object} response.ResponseThreadAndComments
+// @Success 200 {object} response.ResponseComment
 // @Failure 400
 // @Failure 401
 // @Failure 404
@@ -167,23 +157,13 @@ func (co *CommentHandler) edit(c *gin.Context) {
 		Contributor: req.Contributor,
 	}
 
-	comments, err := co.commentApplication.EditComment(&param)
+	comment, err := co.commentApplication.EditComment(&param)
 	if err != nil {
 		handleError(c, err)
 		return
 	}
 
-	thread, err := co.threadApplication.GetByThreadKey(threadKey)
-	if err != nil {
-		handleError(c, err)
-		return
-	}
-
-	var res response.ResponseThreadAndComments
-	res.Thread = response.NewResponseThread(thread)
-	for _, comment := range *comments {
-		res.Comments = append(res.Comments, response.NewResponseComment(&comment))
-	}
+	res := response.NewResponseComment(comment)
 
 	c.JSON(http.StatusOK, res)
 }

--- a/backend/app/interfaces/comment_handler_test.go
+++ b/backend/app/interfaces/comment_handler_test.go
@@ -148,9 +148,6 @@ func TestCommenHandler_create(t *testing.T) {
 	var (
 		correctThreadKey = "correct-thread-key"
 		wrongThreadKey   = "wrong-thread-key"
-		initViews        = 0
-		commentSum       = 0
-		thread           = &domain.Thread{Views: &initViews, CommentSum: &commentSum}
 	)
 	cases := []struct {
 		testCase   string
@@ -199,8 +196,7 @@ func TestCommenHandler_create(t *testing.T) {
 			testCase: "コメント生成もスレッド取得も問題ない場合200となる",
 			prepare: func(mf *mockField) {
 				mf.sessionManager.EXPECT().Get(gomock.Any()).Return(nil, nil)
-				mf.commentApplication.EXPECT().CreateComment(gomock.Any()).Return(&[]domain.Comment{}, nil)
-				mf.threadApplication.EXPECT().GetByThreadKey(correctThreadKey).Return(thread, nil)
+				mf.commentApplication.EXPECT().CreateComment(gomock.Any()).Return(&domain.Comment{}, nil)
 			},
 			threadKey:  correctThreadKey,
 			body:       request.RequestCommentCreate{Comment: "comment", Contributor: "user"},
@@ -215,17 +211,6 @@ func TestCommenHandler_create(t *testing.T) {
 			threadKey:  wrongThreadKey,
 			body:       request.RequestCommentCreate{Comment: "comment", Contributor: "user"},
 			statusCode: http.StatusInternalServerError,
-		},
-		{
-			testCase: "コメント作成後のスレッド取得に失敗した場合は404となる",
-			prepare: func(mf *mockField) {
-				mf.sessionManager.EXPECT().Get(gomock.Any()).Return(nil, nil)
-				mf.commentApplication.EXPECT().CreateComment(gomock.Any()).Return(&[]domain.Comment{}, nil)
-				mf.threadApplication.EXPECT().GetByThreadKey(wrongThreadKey).Return(nil, appError.ErrNotFound)
-			},
-			threadKey:  wrongThreadKey,
-			body:       request.RequestCommentCreate{Comment: "comment", Contributor: "user"},
-			statusCode: http.StatusNotFound,
 		},
 	}
 
@@ -277,9 +262,6 @@ func TestCommentService_edit(t *testing.T) {
 	//
 	var (
 		threadKey  = "thread-key"
-		initViews  = 0
-		commentSum = 0
-		thread     = &domain.Thread{Views: &initViews, CommentSum: &commentSum}
 	)
 	cases := []struct {
 		testCase   string
@@ -328,8 +310,7 @@ func TestCommentService_edit(t *testing.T) {
 			testCase: "コメントの編集に成功した場合は200となる",
 			prepare: func(mf *mockField) {
 				mf.sessionManager.EXPECT().Get(gomock.Any()).Return(nil, nil)
-				mf.commentApplication.EXPECT().EditComment(gomock.Any()).Return(&[]domain.Comment{}, nil)
-				mf.threadApplication.EXPECT().GetByThreadKey(threadKey).Return(thread, nil)
+				mf.commentApplication.EXPECT().EditComment(gomock.Any()).Return(&domain.Comment{}, nil)
 			},
 			threadKey:  threadKey,
 			body:       request.RequestCommentEdit{Comment: "comment", Contributor: "user"},
@@ -344,17 +325,6 @@ func TestCommentService_edit(t *testing.T) {
 			threadKey:  threadKey,
 			body:       request.RequestCommentEdit{Comment: "comment", Contributor: "user"},
 			StatusCode: http.StatusInternalServerError,
-		},
-		{
-			testCase: "コメント編集後のスレッド取得に失敗した場合は404となる",
-			prepare: func(mf *mockField) {
-				mf.sessionManager.EXPECT().Get(gomock.Any()).Return(nil, nil)
-				mf.commentApplication.EXPECT().EditComment(gomock.Any()).Return(&[]domain.Comment{}, nil)
-				mf.threadApplication.EXPECT().GetByThreadKey(threadKey).Return(nil, appError.ErrNotFound)
-			},
-			threadKey:  threadKey,
-			body:       request.RequestCommentEdit{Comment: "comment", Contributor: "user"},
-			StatusCode: http.StatusNotFound,
 		},
 	}
 

--- a/backend/app/mock/application/comment_app.go
+++ b/backend/app/mock/application/comment_app.go
@@ -36,10 +36,10 @@ func (m *MockCommentApplication) EXPECT() *MockCommentApplicationMockRecorder {
 }
 
 // CreateComment mocks base method.
-func (m *MockCommentApplication) CreateComment(param *params.CreateCommentAppLayerParam) (*[]domain.Comment, error) {
+func (m *MockCommentApplication) CreateComment(param *params.CreateCommentAppLayerParam) (*domain.Comment, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateComment", param)
-	ret0, _ := ret[0].(*[]domain.Comment)
+	ret0, _ := ret[0].(*domain.Comment)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -65,10 +65,10 @@ func (mr *MockCommentApplicationMockRecorder) DeleteComment(param interface{}) *
 }
 
 // EditComment mocks base method.
-func (m *MockCommentApplication) EditComment(param *params.EditCommentAppLayerParam) (*[]domain.Comment, error) {
+func (m *MockCommentApplication) EditComment(param *params.EditCommentAppLayerParam) (*domain.Comment, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EditComment", param)
-	ret0, _ := ret[0].(*[]domain.Comment)
+	ret0, _ := ret[0].(*domain.Comment)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -306,7 +306,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/response.ResponseThreadAndComments"
+                            "$ref": "#/definitions/response.ResponseComment"
                         }
                     },
                     "400": {
@@ -366,7 +366,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/response.ResponseThreadAndComments"
+                            "$ref": "#/definitions/response.ResponseComment"
                         }
                     },
                     "400": {

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -299,7 +299,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/response.ResponseThreadAndComments"
+                            "$ref": "#/definitions/response.ResponseComment"
                         }
                     },
                     "400": {
@@ -359,7 +359,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/response.ResponseThreadAndComments"
+                            "$ref": "#/definitions/response.ResponseComment"
                         }
                     },
                     "400": {

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -321,7 +321,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/response.ResponseThreadAndComments'
+            $ref: '#/definitions/response.ResponseComment'
         "400":
           description: ""
         "401":
@@ -392,7 +392,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/response.ResponseThreadAndComments'
+            $ref: '#/definitions/response.ResponseComment'
         "400":
           description: ""
         "401":


### PR DESCRIPTION
Fixes #61

- コメントAPIで作成と更新の時にリターンされるものがAPIの文脈から乖離してしまっていたので、直感的に理解できるリターン値に変更しました
- 合わせてapplication層のロジックも変更しています