### PR TITLE
新規作成と更新時に投稿者の情報をフロントから送らない

### DIFF
--- a/backend/app/application/comment_app.go
+++ b/backend/app/application/comment_app.go
@@ -46,9 +46,14 @@ func (c *commentApplication) CreateComment(param *appParams.CreateCommentAppLaye
 		return nil, err
 	}
 
+	user, err := c.userRepo.GetByID(param.UserID)
+	if err != nil {
+		return nil, err
+	}
+
 	domainParam := domainParams.CreateCommentDomainLayerParam{
 		ThreadKey:   param.ThreadKey,
-		Contributor: param.Contributor,
+		Contributor: user.Username,
 		Comment:     param.Comment,
 	}
 
@@ -82,16 +87,21 @@ func (c *commentApplication) EditComment(param *appParams.EditCommentAppLayerPar
 		return nil, err
 	}
 
+	user, err := c.userRepo.GetByID(param.UserID)
+	if err != nil {
+		return nil, err
+	}
+
 	// 同じ投稿者でなければ編集することはできない
-	if comment.IsNotSameContritubor(param.Contributor) {
+	if comment.IsNotSameContritubor(user.Username) {
 		logger.Warning(
 			"comment conributor and edit contributor is not same",
 			"comment_contributor", comment.GetContributor(),
-			"requesting_contiributor", param.Contributor,
+			"requesting_contiributor", user.Username,
 		)
 		return nil, appError.NewErrBadRequest(
 			appError.Message().NotSameContributor,
-			"contibutor is %s, but edit requesting user is %s", comment.GetContributor(), param.Contributor,
+			"contibutor is %s, but edit requesting user is %s", comment.GetContributor(), user.Username,
 		)
 	}
 

--- a/backend/app/application/params/comment.go
+++ b/backend/app/application/params/comment.go
@@ -1,16 +1,16 @@
 package params
 
 type CreateCommentAppLayerParam struct {
-	ThreadKey   string
-	Comment     string
-	Contributor string
+	ThreadKey string
+	Comment   string
+	UserID    string
 }
 
 type EditCommentAppLayerParam struct {
-	ThreadKey   string
-	CommentKey  string
-	Comment     string
-	Contributor string
+	ThreadKey  string
+	CommentKey string
+	Comment    string
+	UserID     string
 }
 
 type DeleteCommentAppLayerParam struct {

--- a/backend/app/application/params/thread.go
+++ b/backend/app/application/params/thread.go
@@ -1,14 +1,14 @@
 package params
 
 type CreateThreadAppLayerParam struct {
-	Title       string
-	Contributor string
+	Title  string
+	UserID string
 }
 
 type EditThreadAppLayerParam struct {
-	ThreadKey   string
-	Title       string
-	Contributor string
+	ThreadKey string
+	Title     string
+	UserID    string
 }
 
 type DeleteThreadAppLayerParam struct {

--- a/backend/app/application/thread_app.go
+++ b/backend/app/application/thread_app.go
@@ -51,9 +51,14 @@ func (t *threadApplication) GetByThreadKey(threadKey string) (*domain.Thread, er
 }
 
 func (t *threadApplication) CreateThread(param *appParams.CreateThreadAppLayerParam) (*domain.Thread, error) {
+	user, err := t.userRepo.GetByID(param.UserID)
+	if err != nil {
+		return nil, err
+	}
+
 	domainParam := domainParams.CreateThreadDomainLayerParam{
 		Title:       param.Title,
-		Contributor: param.Contributor,
+		Contributor: user.Username,
 	}
 
 	newThread := domain.NewThread(&domainParam)
@@ -72,15 +77,20 @@ func (t *threadApplication) EditThread(param *appParams.EditThreadAppLayerParam)
 		return nil, err
 	}
 
-	if thread.IsNotSameContributor(param.Contributor) {
+	user, err := t.userRepo.GetByID(param.UserID)
+	if err != nil {
+		return nil, err
+	}
+
+	if thread.IsNotSameContributor(user.Username) {
 		logger.Warning(
 			"thread contibutor and edit requesting contributor is not same",
 			"thread_contributor", thread.GetContributor(),
-			"requesting_contributor", param.Contributor,
+			"requesting_contributor", user.Username,
 		)
 		return nil, appError.NewErrBadRequest(
 			appError.Message().NotSameContributor,
-			"contibutor is %s, but edit requesting user is %s", thread.GetContributor(), param.Contributor,
+			"contibutor is %s, but edit requesting user is %s", thread.GetContributor(), user.Username,
 		)
 	}
 

--- a/backend/app/interfaces/comment_handler.go
+++ b/backend/app/interfaces/comment_handler.go
@@ -98,6 +98,7 @@ func (co *CommentHandler) getAll(c *gin.Context) {
 // Comment godoc
 func (co *CommentHandler) create(c *gin.Context) {
 	threadKey := c.Param("threadKey")
+	user, _ := co.sessionManager.Get(c)
 
 	var req request.RequestCommentCreate
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -107,9 +108,9 @@ func (co *CommentHandler) create(c *gin.Context) {
 	}
 
 	param := params.CreateCommentAppLayerParam{
-		ThreadKey:   threadKey,
-		Comment:     req.Comment,
-		Contributor: req.Contributor,
+		ThreadKey: threadKey,
+		Comment:   req.Comment,
+		UserID:    user.UserID,
 	}
 
 	comment, err := co.commentApplication.CreateComment(&param)
@@ -142,6 +143,7 @@ func (co *CommentHandler) create(c *gin.Context) {
 func (co *CommentHandler) edit(c *gin.Context) {
 	threadKey := c.Param("threadKey")
 	commentKey := c.Param("commentKey")
+	user, _ := co.sessionManager.Get(c)
 
 	var req request.RequestCommentEdit
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -151,10 +153,10 @@ func (co *CommentHandler) edit(c *gin.Context) {
 	}
 
 	param := params.EditCommentAppLayerParam{
-		ThreadKey:   threadKey,
-		CommentKey:  commentKey,
-		Comment:     req.Comment,
-		Contributor: req.Contributor,
+		ThreadKey:  threadKey,
+		CommentKey: commentKey,
+		Comment:    req.Comment,
+		UserID:     user.UserID,
 	}
 
 	comment, err := co.commentApplication.EditComment(&param)

--- a/backend/app/interfaces/request/comment.go
+++ b/backend/app/interfaces/request/comment.go
@@ -2,10 +2,8 @@ package request
 
 type RequestCommentCreate struct {
 	Comment     string `json:"comment" binding:"required"`
-	Contributor string `json:"contributor" binding:"required"`
 }
 
 type RequestCommentEdit struct {
 	Comment     string `json:"comment" binding:"required"`
-	Contributor string `json:"contributor" binding:"required"`
 }

--- a/backend/app/interfaces/request/thread.go
+++ b/backend/app/interfaces/request/thread.go
@@ -2,10 +2,8 @@ package request
 
 type RequestThreadCreate struct {
 	Title       string `json:"title" binding:"required"`
-	Contributor string `json:"contributor" binding:"required"`
 }
 
 type RequestThreadEdit struct {
 	Title       string `json:"title" binding:"required"`
-	Contributor string `json:"contributor" binding:"required"`
 }

--- a/backend/app/interfaces/thread_handler.go
+++ b/backend/app/interfaces/thread_handler.go
@@ -118,9 +118,11 @@ func (t *ThreadHandler) create(c *gin.Context) {
 		return
 	}
 
+	user, _ := t.sessionManager.Get(c)
+
 	param := params.CreateThreadAppLayerParam{
-		Title:       req.Title,
-		Contributor: req.Contributor,
+		Title:  req.Title,
+		UserID: user.UserID,
 	}
 
 	thread, err := t.threadApplication.CreateThread(&param)
@@ -150,6 +152,7 @@ func (t *ThreadHandler) create(c *gin.Context) {
 // Thread godoc
 func (t *ThreadHandler) edit(c *gin.Context) {
 	threadKey := c.Param("threadKey")
+	user, _ := t.sessionManager.Get(c)
 
 	var req request.RequestThreadEdit
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -159,9 +162,9 @@ func (t *ThreadHandler) edit(c *gin.Context) {
 	}
 
 	param := params.EditThreadAppLayerParam{
-		ThreadKey:   threadKey,
-		Title:       req.Title,
-		Contributor: req.Contributor,
+		ThreadKey: threadKey,
+		Title:     req.Title,
+		UserID:    user.UserID,
 	}
 
 	thread, err := t.threadApplication.EditThread(&param)

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -707,14 +707,10 @@ const docTemplate = `{
         "request.RequestCommentCreate": {
             "type": "object",
             "required": [
-                "comment",
-                "contributor"
+                "comment"
             ],
             "properties": {
                 "comment": {
-                    "type": "string"
-                },
-                "contributor": {
                     "type": "string"
                 }
             }
@@ -722,14 +718,10 @@ const docTemplate = `{
         "request.RequestCommentEdit": {
             "type": "object",
             "required": [
-                "comment",
-                "contributor"
+                "comment"
             ],
             "properties": {
                 "comment": {
-                    "type": "string"
-                },
-                "contributor": {
                     "type": "string"
                 }
             }
@@ -767,13 +759,9 @@ const docTemplate = `{
         "request.RequestThreadCreate": {
             "type": "object",
             "required": [
-                "contributor",
                 "title"
             ],
             "properties": {
-                "contributor": {
-                    "type": "string"
-                },
                 "title": {
                     "type": "string"
                 }
@@ -782,13 +770,9 @@ const docTemplate = `{
         "request.RequestThreadEdit": {
             "type": "object",
             "required": [
-                "contributor",
                 "title"
             ],
             "properties": {
-                "contributor": {
-                    "type": "string"
-                },
                 "title": {
                     "type": "string"
                 }

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -700,14 +700,10 @@
         "request.RequestCommentCreate": {
             "type": "object",
             "required": [
-                "comment",
-                "contributor"
+                "comment"
             ],
             "properties": {
                 "comment": {
-                    "type": "string"
-                },
-                "contributor": {
                     "type": "string"
                 }
             }
@@ -715,14 +711,10 @@
         "request.RequestCommentEdit": {
             "type": "object",
             "required": [
-                "comment",
-                "contributor"
+                "comment"
             ],
             "properties": {
                 "comment": {
-                    "type": "string"
-                },
-                "contributor": {
                     "type": "string"
                 }
             }
@@ -760,13 +752,9 @@
         "request.RequestThreadCreate": {
             "type": "object",
             "required": [
-                "contributor",
                 "title"
             ],
             "properties": {
-                "contributor": {
-                    "type": "string"
-                },
                 "title": {
                     "type": "string"
                 }
@@ -775,13 +763,9 @@
         "request.RequestThreadEdit": {
             "type": "object",
             "required": [
-                "contributor",
                 "title"
             ],
             "properties": {
-                "contributor": {
-                    "type": "string"
-                },
                 "title": {
                     "type": "string"
                 }

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -11,21 +11,15 @@ definitions:
     properties:
       comment:
         type: string
-      contributor:
-        type: string
     required:
     - comment
-    - contributor
     type: object
   request.RequestCommentEdit:
     properties:
       comment:
         type: string
-      contributor:
-        type: string
     required:
     - comment
-    - contributor
     type: object
   request.RequestSignIn:
     properties:
@@ -49,22 +43,16 @@ definitions:
     type: object
   request.RequestThreadCreate:
     properties:
-      contributor:
-        type: string
       title:
         type: string
     required:
-    - contributor
     - title
     type: object
   request.RequestThreadEdit:
     properties:
-      contributor:
-        type: string
       title:
         type: string
     required:
-    - contributor
     - title
     type: object
   response.ResponseComment:

--- a/frontend/src/components/organisms/comment/CommentBoard.tsx
+++ b/frontend/src/components/organisms/comment/CommentBoard.tsx
@@ -25,7 +25,6 @@ export const CommentBoard: React.FC<CommentBoardProps> = (props) => {
                 commentKey: props.comment.commentKey,
                 body: {
                     comment,
-                    contributor: props.comment.contributor,
                 },
             })
         );

--- a/frontend/src/components/organisms/form/CommentPostForm.tsx
+++ b/frontend/src/components/organisms/form/CommentPostForm.tsx
@@ -6,7 +6,6 @@ import { PrimaryButton } from "../../atoms/button/PrimaryButton";
 import { commentSagaActions } from "../../../state/comments/modules";
 
 type CommentPostFormProps = {
-    loginUsername: string;
     threadKey: string | undefined;
 };
 
@@ -28,7 +27,6 @@ export const CommentPostform: React.FC<CommentPostFormProps> = (props) => {
                     threadKey: props.threadKey,
                     body: {
                         comment,
-                        contributor: props.loginUsername,
                     },
                 })
             );

--- a/frontend/src/components/organisms/form/ThreadPostForm.tsx
+++ b/frontend/src/components/organisms/form/ThreadPostForm.tsx
@@ -4,11 +4,7 @@ import { Text, Input, Box } from "@chakra-ui/react";
 import { PrimaryButton } from "../../atoms/button/PrimaryButton";
 import { threadSagaActions } from "../../../state/threads/modules";
 
-type ThreadPostFormProps = {
-    loginUsername: string;
-};
-
-export const ThreadPostForm: React.FC<ThreadPostFormProps> = (props) => {
+export const ThreadPostForm: React.FC = (props) => {
     const dispatch = useDispatch();
     const [value, setValue] = useState("");
     const [buttonDisabled, setButtonDisabled] = useState(true);
@@ -23,7 +19,6 @@ export const ThreadPostForm: React.FC<ThreadPostFormProps> = (props) => {
         dispatch(
             threadSagaActions.create({
                 title: value,
-                contributor: props.loginUsername,
             })
         );
         setValue("");

--- a/frontend/src/components/organisms/thread/ThreadBoard.tsx
+++ b/frontend/src/components/organisms/thread/ThreadBoard.tsx
@@ -24,7 +24,6 @@ export const ThreadBoard: React.FC<ThreadBoadProps> = (props) => {
             threadKey: props.thread.threadKey,
             body: {
                 title,
-                contributor: props.thread.contributor,
             }
         };
         dispatch(threadSagaActions.update(updateThreadPayload));

--- a/frontend/src/pages/threads/Page.tsx
+++ b/frontend/src/pages/threads/Page.tsx
@@ -27,7 +27,7 @@ export const Home: React.FC = () => {
                 today={visitorState.today}
                 sum={visitorState.sum}
             ></VisitorStat>
-            {userState.username === "" || <ThreadPostForm loginUsername={userState.username}></ThreadPostForm>}
+            {userState.username === "" || <ThreadPostForm></ThreadPostForm>}
             <ThreadsBoardList threads={threadState.threads}></ThreadsBoardList>
         </>
     );

--- a/frontend/src/pages/threads/comments/Page.tsx
+++ b/frontend/src/pages/threads/comments/Page.tsx
@@ -29,7 +29,7 @@ export const ThreadContent: React.FC = () => {
                 ></ThreadBoard>
             </Box>
             {userState.username === "" || (
-                <CommentPostform loginUsername={userState.username} threadKey={urlParams.threadKey}></CommentPostform>
+                <CommentPostform threadKey={urlParams.threadKey}></CommentPostform>
             )}
             <CommentBoardList
                 threadKey={commentState.thread.threadKey}

--- a/frontend/src/state/comments/modules.ts
+++ b/frontend/src/state/comments/modules.ts
@@ -12,7 +12,6 @@ export type CreateCommentPayload = {
     threadKey: string;
     body: {
         comment: string;
-        contributor: string;
     };
 };
 
@@ -21,7 +20,6 @@ export type UpdateCommentPayload = {
     commentKey: string;
     body: {
         comment: string;
-        contributor: string;
     };
 };
 

--- a/frontend/src/state/threads/modules.ts
+++ b/frontend/src/state/threads/modules.ts
@@ -10,14 +10,12 @@ import {
 // ---- Payload ---- //
 export type CreateThreadPayload = {
     title: string;
-    contributor: string;
 };
 
 export type UpdateThreadPayload = {
     threadKey: string;
     body: {
         title: string;
-        contributor: string;
     };
 };
 


### PR DESCRIPTION
Fixes #62

- これまで新規作成と更新の時に投稿者をバックエンドに送信していましたが、それをバックエンドのセッションから判断するようにしました
- それに合わせてバックエンド/フロントエンド両方修正しています